### PR TITLE
Polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
- - Refactored all tests to use fixtures instead of xunit style testing
+ - `send` is now a group type of command which has `message`, `file` and `poll`
+ subcommands.
+ - Moved file sending functionality from `send` to `send file`
+ - Moved message sending functionality from `send` to `send message`
+ - `send` now only takes receiver chat id, other subcommands take related
+ options and parameters
 
 ## [v0.1.2] - 2019-04-19
 ### Added

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -90,6 +90,27 @@ def bot_send_message_request(
 
 
 @pytest.fixture
+def bot_send_poll_request(bot_session) -> tgcli.request.bot.SendPollRequest:
+    """
+    Returns a bot send poll request.
+
+    Fixtures
+    --------
+    bot_session
+
+    Attributes
+    ----------
+    session = bot_session
+    chat_id = 1
+    question = "Foo?"
+    options = ("Bar", "Baz")
+    """
+    return tgcli.request.bot.SendPollRequest(
+        bot_session, 1, "Foo?", ("Bar", "Baz")
+    )
+
+
+@pytest.fixture
 def bot_send_document_request_factory(bot_session) -> callable:
     """
     Returns a bot send document request factory.

--- a/tests/test_request/test_bot.py
+++ b/tests/test_request/test_bot.py
@@ -214,3 +214,33 @@ class TestSendDocumentRequest:
 
     def test_request_body_document(self, bot_send_document_request):
         assert b'filename="file.png"' in bot_send_document_request.body
+
+
+class TestSendPollRequest:
+    def test_url(self, bot_send_poll_request):
+        assert bot_send_poll_request.url[-8:] == "sendPoll"
+
+    def test_request_body_chat_id(
+        self, bot_send_poll_request, request_body_factory
+    ):
+        request_body = request_body_factory(bot_send_poll_request)
+        assert request_body.get("chat_id") == 1
+
+    def test_request_body_question(
+        self, bot_send_poll_request, request_body_factory
+    ):
+        request_body = request_body_factory(bot_send_poll_request)
+        assert request_body.get("question") == "Foo?"
+
+    def test_request_body_options(
+        self, bot_send_poll_request, request_body_factory
+    ):
+        request_body = request_body_factory(bot_send_poll_request)
+        assert request_body.get("options")[0] == "Bar"
+        assert request_body.get("options")[1] == "Baz"
+
+    def test_request_body_disable_notification(
+        self, bot_send_poll_request, request_body_factory
+    ):
+        request_body = request_body_factory(bot_send_poll_request)
+        assert not request_body.get("disable_notification")

--- a/tgcli/cli.py
+++ b/tgcli/cli.py
@@ -1,13 +1,13 @@
 import io
 import platform
 import sys
+import typing
 
 import click
 import colorful
+import tgcli.request.bot
 import yaspin
 import yaspin.spinners
-
-import tgcli.request.bot
 
 IS_DARWIN = platform.system().lower() == "darwin"
 
@@ -15,75 +15,16 @@ IS_DARWIN = platform.system().lower() == "darwin"
 MESSAGE_FORMATS = {"html": "HTML", "markdown": "Markdown"}
 MEDIA_TYPES = [str(v.value) for v in list(tgcli.request.bot.MediaType)]
 
-
-@click.group()
-@click.option(
-    "--secure/--no-secure",
-    default=(not IS_DARWIN),
-    help='Whether to validate HTTPS requests. Default is "secure" except OSX. '
-    'You have to update built-in OpenSSL and manually pass "secure" each '
-    "time in OSX.",
-)
-@click.pass_context
-def cli(ctx, secure: bool):
-    ctx.obj = dict()
-    ctx.obj["secure"] = secure
-
-
-@cli.group()
-@click.option(
-    "-t",
-    "--token",
-    envvar="TELEGRAM_BOT_TOKEN",
-    required=True,
-    help="Token of bot. Can be provided via TELEGRAM_BOT_TOKEN environment variable.",
-)
-@click.pass_context
-def bot(ctx, token):
-    ctx.obj["token"] = token
-
-
-@bot.command()
-@click.option(
-    "--format",
-    default="markdown",
-    type=click.Choice(MESSAGE_FORMATS.keys()),
-    help='Format of the message. Default is "markdown".',
-)
-@click.option("-f", "--file", type=click.File("rb"), help="File to send.")
-@click.option(
-    "--as",
-    "as_",
-    default="document",
-    type=click.Choice(MEDIA_TYPES),
-    help='Send the file as as type. Default is "document".',
-)
-@click.option(
-    "-r", "--receiver", required=True, help="Receiver of the message."
-)
-@click.argument("message", required=True)
-@click.pass_context
-def send(
-    ctx, format: str, file: io.BytesIO, as_: str, receiver: str, message: str
+###########
+# Commons #
+###########
+def send_message(
+    session: tgcli.request.bot.BotSession,
+    request: tgcli.request.bot.BotRequest,
 ):
-    session = tgcli.request.bot.BotSession(ctx.obj["token"])
-    session.verify = ctx.obj["secure"]
-
-    if file:
-        request = tgcli.request.bot.SendFileRequest(
-            session,
-            receiver,
-            file,
-            message,
-            tgcli.request.bot.MediaType(as_),
-            MESSAGE_FORMATS[format],
-        )
-        file.close()
-    else:
-        request = tgcli.request.bot.SendMessageRequest(
-            session, receiver, message, MESSAGE_FORMATS[format]
-        )
-
+    """
+    Sends message using Yaspin.
+    """
     with yaspin.yaspin(yaspin.spinners.Spinners.clock) as spinner:
         spinner.text = "Sending message..."
         response = session.send(request)
@@ -108,3 +49,135 @@ def send(
             spinner.text = "Failed sending message."
             spinner.fail("❌")
             sys.exit(1)
+
+
+##########
+## Root ##
+##########
+@click.group()
+@click.option(
+    "--secure/--no-secure",
+    default=(not IS_DARWIN),
+    help='Whether to validate HTTPS requests. Default is "secure" except OSX. '
+    'You have to update built-in OpenSSL and manually pass "secure" each '
+    "time in OSX.",
+)
+@click.pass_context
+def cli(ctx, secure: bool):
+    ctx.obj = dict()
+    ctx.obj["secure"] = secure
+
+
+#######
+# Bot #
+#######
+@cli.group()
+@click.option(
+    "-t",
+    "--token",
+    envvar="TELEGRAM_BOT_TOKEN",
+    required=True,
+    help="Token of bot. Can be provided via TELEGRAM_BOT_TOKEN environment variable.",
+)
+@click.pass_context
+def bot(ctx, token):
+    ctx.obj["token"] = token
+
+
+# send #
+@bot.group()
+@click.option(
+    "-r", "--receiver", required=True, help="Receiver of the message."
+)
+@click.pass_context
+def send(ctx, receiver: str):
+    ctx.obj["receiver"] = receiver
+
+
+# send types
+FORMAT_OPTION = click.option(
+    "--format",
+    default="markdown",
+    type=click.Choice(MESSAGE_FORMATS.keys()),
+    help='Format of the message. Default is "markdown".',
+)
+
+
+@send.command()
+@FORMAT_OPTION
+@click.argument("message", required=True)
+@click.pass_context
+def message(ctx, format: str, message: str):
+    session = tgcli.request.bot.BotSession(ctx.obj["token"])
+    session.verify = ctx.obj["secure"]
+    receiver = ctx.obj["receiver"]
+
+    request = tgcli.request.bot.SendMessageRequest(
+        session, receiver, message, MESSAGE_FORMATS[format]
+    )
+
+    send_message(session, request)
+
+
+@send.command()
+@click.option(
+    "-m", "--message", default="", help="The message to inline with file."
+)
+@FORMAT_OPTION
+@click.option(
+    "--as",
+    "as_",
+    default="document",
+    type=click.Choice(MEDIA_TYPES),
+    help='Send the file as as type. Default is "document".',
+)
+@click.argument("file", type=click.File("rb"), required=True)
+@click.pass_context
+def file(ctx, message: str, format: str, as_: str, file: str):
+    session = tgcli.request.bot.BotSession(ctx.obj["token"])
+    session.verify = ctx.obj["secure"]
+    receiver = ctx.obj["receiver"]
+
+    request = tgcli.request.bot.SendFileRequest(
+        session,
+        receiver,
+        file,
+        message,
+        tgcli.request.bot.MediaType(as_),
+        MESSAGE_FORMATS[format],
+    )
+    file.close()
+
+    send_message(session, request)
+
+
+@send.command()
+@click.option(
+    "-o",
+    "--option",
+    "options",
+    multiple=True,
+    help="An option for poll question. You can define multiple option.",
+)
+@click.argument("question", required=True)
+@click.pass_context
+def poll(ctx, options: typing.Tuple[str], question: str):
+    if len(options) < 2:
+        error_messages = (
+            "You need to provide at least two options.",
+            "You have provided only one option."
+            if len(options) == 1
+            else "You have provided no options.",
+        )
+
+        raise click.BadParameter(" ".join(error_messages))
+
+    session = tgcli.request.bot.BotSession(ctx.obj["token"])
+    session.verify = ctx.obj["secure"]
+    receiver = ctx.obj["receiver"]
+
+    request = tgcli.request.bot.SendPollRequest(
+        session, receiver, question, options
+    )
+
+    send_message(session, request)

--- a/tgcli/request/bot.py
+++ b/tgcli/request/bot.py
@@ -76,6 +76,34 @@ class SendMessageRequest(BotRequest):
         )
 
 
+class SendPollRequest(BotRequest):
+    def __init__(
+        self,
+        session: BotSession,
+        chat_id: typing.Union[str, int],
+        question: str,
+        options: typing.Iterable[str],
+        disable_notification: bool = False,
+    ):
+        try:
+            chat_id = int(chat_id)
+        except ValueError:  # pragma: no cover
+            pass  # pragma: no cover
+
+        super().__init__(session, "sendPoll")
+        self.prepare_method("post")
+        self.prepare_body(
+            data=None,
+            files=None,
+            json={
+                "chat_id": chat_id,
+                "question": str(question),
+                "options": tuple(options),
+                "disable_notification": bool(disable_notification),
+            },
+        )
+
+
 @enum.unique
 class MediaType(enum.Enum):
     DOCUMENT = "document"


### PR DESCRIPTION
### Changed
 - `send` is now a group type of command which has `message`, `file` and `poll`
 subcommands.
 - Moved file sending functionality from `send` to `send file`
 - Moved message sending functionality from `send` to `send message`
 - `send` now only takes receiver chat id, other subcommands take related
 options and parameters