### PR TITLE
v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+ - Refactored all tests to use fixtures instead of xunit style testing
+
 ## [v0.1.2] - 2019-04-19
 ### Added
  - Downloads counter to README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.2.0] - 2019-04-19
 ### Added
  - `poll` section to *Bot* documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - `poll` section to *Bot* documentation
+
 ### Changed
  - `send` is now a group type of command which has `message`, `file` and `poll`
  subcommands.
@@ -12,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Moved message sending functionality from `send` to `send message`
  - `send` now only takes receiver chat id, other subcommands take related
  options and parameters
+ - Updated *Bot* section of documentation
 
 ## [v0.1.2] - 2019-04-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.2] - 2019-04-19
+### Added
+ - Downloads counter to README
+
+### Changed
+ - Changes status from beta to stable
+
+### Removed
+ - Status badge from README
+
 ## [v0.1.1] - 2019-04-13
 ### Changed
  - Changed documentation theme to material.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pip install tgcli
 For now, the use case is pretty simple. To send a message:
 
 ```python
-tgcli bot --token "BotToken" send --receiver "UserID" "Your message"
+tgcli bot --token "BotToken" send --receiver "UserID" message "Your message"
 ```
 
 You don't need to expose your token as flag. If you set
@@ -63,4 +63,8 @@ and `TELEGRAM_RECEIVER` environment variables were set.
 This application serves a really small purpose for now. It might face
 breaking changes in the future.
 
-For more information, refer to the [documentation](https://tgcli.readthedocs.io/en/latest/).
+## Documentation
+
+Documentation has an intensive amount of  information about how to
+use `tgcli`. Refer to the
+[documentation](https://tgcli.readthedocs.io/en/latest/).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![PyPI](https://img.shields.io/pypi/v/tgcli.svg?style=flat-square&logo=python&logoColor=white)][pypi_url]
 [![PyPI](https://img.shields.io/pypi/dm/tgcli.svg?style=flat-square&logo=python&logoColor=white)][pypi_url]
 [![PyPI](https://img.shields.io/pypi/pyversions/tgcli.svg?style=flat-square&logo=python&logoColor=white)][pypi_url]
-[![PyPI](https://img.shields.io/pypi/status/tgcli.svg?style=flat-square&logo=python&logoColor=white)][pypi_url]
 [![PyPI](https://img.shields.io/pypi/l/tgcli.svg?style=flat-square)][pypi_url]
 [![](https://img.shields.io/readthedocs/tgcli.svg?style=flat-square)](https://tgcli.readthedocs.io/en/latest/)
 [![Telegram](https://img.shields.io/badge/telegram-%40erayerdin-%2332afed.svg?style=flat-square&logo=telegram&logoColor=white)](https://t.me/erayerdin)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ("tests.fixtures",)

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -14,8 +14,8 @@ Short Flag | Full Flag | Required/Optional | Description
 --- | --- | --- | ---
 -t | --token | Required[^1] | Token of bot.
 
-[^1]: It is not required if you have `TELEGRAM_BOT_TOKEN` set in your current
-      shell session.
+[^1]: It is not required if you have `TELEGRAM_BOT_TOKEN` environment variable
+      set in your current shell session.
 
 !!! tip
     You can also pass `TELEGRAM_BOT_TOKEN` environment variable to current
@@ -29,31 +29,110 @@ Short Flag | Full Flag | Required/Optional | Description
 
 ## send
 
-A subcommand of `bot` to send regular messages to any person, to get help:
+`send` is a subcommand of `bot` which, hence the name, operate sending
+operations. To get help:
 
     tgcli bot send --help
 
+`send` has only one option:
+
 Short Flag | Full Flag | Required/Optional | Description
 --- | --- | --- | ---
--t | --token | Required[^2] | Token of bot.
--r | --receiver | Required | The receiver's ID. An integer.
- | --format | Optional | The format of message. Choices are `markdown` and `html`. Default is `markdown`.
--f | --file[^2] | Optional | File to send.
- | --as | Optional | Type of the file that is sent. Choices are `document`, `video`, `audio` and `photo`. Default is `document`.
- | message | Required | The message.
+-r | --receiver | Required | The receiver's ID, an integer.
 
-[^2]: File storage in Telegram server is a bit complex topic, which is
-      discussed in [file storage and media types section](bot.md#file-storage-and-media-types)
-      of the documentation.
+After you define the receiver's ID, then you can use any subcommand of `send`.
+To give an example:
+
+    tgcli bot send -r $RECEIVER_ID message "Hello, world!"
+
+Assuming you have replaced `$RECEIVER_ID` with a user or group id, this is how
+you send a message.
+
+!!! note
+    You *have to* define `-r`/`--receiver`  in order to use any subcommand of
+    `send`, even if what you need is only `--help`.
 
 !!! tip
     ID of a user  *is not* username or human-readable name. It is an integer
     representing the account. To get your ID, send
     [@userinfobot](https://t.me/userinfobot) *any* message.
 
-## File Storage and Media Types
+### message
 
-### Notes on Limits of File Storage
+`message` is a subcommand of `send` command and is used to send *regular*
+messages. To get help:
+
+    tgcli bot send -r $RECEIVER_ID message --help
+
+`message` has the options and parameters below:
+
+Short Flag | Full Flag | Required/Optional | Description
+--- | --- | --- | ---
+ | --format | Optional | The format of message. Choices are `markdown` and `html`. Default is `markdown`.
+ | message | Required | The message.
+
+In order to send a message, do:
+
+    tgcli bot send -r $RECEIVER_ID message "foo"
+
+`--format` helps you define the format of your message. See the example:
+
+    tgcli bot send -r $RECEIVER_ID message "<b>bold</b>" --format html
+
+!!! warning
+    Since Telegram also targets the mobile environment, it is safe to assume
+    that not all features and/or tags of markdown and/or HTML are supported.
+    Before using different features or tags, see
+    [this part of the official bot API documentation][telegram_bot_api_markdown]
+    for *Markdown* and
+    [this part of the official bot API documentation][telegram_bot_api_html] for
+    *HTML* in order to see the limitations.
+
+[telegram_bot_api_markdown]: https://core.telegram.org/bots/api#markdown-style
+[telegram_bot_api_html]: https://core.telegram.org/bots/api#html-style
+
+### file
+
+`file` is a subcommand of `send` and is used to send files through `tgcli`. To
+get help:
+
+tgcli bot send -r $RECEIVER_ID file --help
+
+`file` has the options and parameters below:
+
+Short Flag | Full Flag | Required/Optional | Description
+--- | --- | --- | ---
+-m | --message | Optional | The message.
+ | --format | Optional | The format of message. Choices are `markdown` and `html`. Default is `markdown`.
+ | --as | Optional | Type of the file that is sent. Choices are `document`, `video`, `audio` and `photo`. Default is `document`.
+ | file | Required | Path to file.
+
+In order to send a file, do:
+
+    tgcli bot send -r $RECEIVER_ID file path/to/file
+
+#### File Types
+
+`document` is the default option for `--as` flag and it can be used for *all
+types of files*. However, when you set `--as` to a different type, Telegram
+constructs a custom message based on this type. While `document` type only has
+a *download* button, `video` and `audio` have a *play* button and `video` and
+`photo` can be displayed *full-screen*. That is why you might want to set `--as`
+flag if you want further features on the client side. See the example:
+
+    tgcli bot send -r $RECEIVER_ID file path/to/file.png --as photo
+
+Also, you should keep in mind that Telegram might *compress* the files, the
+types of which are all except `document`. So, if you don't want the loss of
+quality in your files, send them as `document` (which will lack additional
+features like play button or showing full-screen).
+
+Lastly, neither Telegram nor `tgcli` checks mimetypes of the files you send for
+performance reasons. So, you might come across weird quirks if you send a file
+with a different types, such as an image having a play button, an audio that can
+be displayed full-screen etc.
+
+#### File Storage Limits
 
 The file storage limit for a bot up to 10 megabytes for photos and 50 megabytes
 for other files
@@ -62,45 +141,13 @@ Also, when you send a file, the message is limited to have up to 1024
 characters for all media types.
 
 While we don't know how long the files are kept in the server, it is safe to
-assume that Telegram server will wipe files depending on when they are accessed,
-if they are forwarded or saved and when the last login of forwarders or savers
-was. And it is even *safer to assume that bots' files will be higher priority in
+assume that Telegram server will wipe files depending on:
+ - when they are accessed,
+ - if they are forwarded or saved and/or
+ - when the last login of forwarders or savers was
+ - et cetera
+
+And it is even *safer to assume that bots' files will be higher priority in
 wiping operations*. That's why it is a good practice to forward the files sent
 by bots to *Saved Messages*, even better to backup them to a storage that you
 own if these files have higher importance to you.
-
-### Notes on Media Types
-
-`document` is the default option for `--as` flag and it can be used for *all
-types of files*. However, when you set `--as` to a different type, Telegram
-constructs a custom message based on this type. While `document` type only has
-a *download* button, `video` and `audio` have a *play* button and `video` and
-`photo` can be displayed *full-screen*. That is why you might want to set `--as`
-flag if you want further features.
-
-Also, you should keep in mind that Telegram might *compress* the files, the
-sending types of which are all except `document`. So, if you don't want the
-loss of quality in your files, send them as `document` (which will lack
-additional features like play button or showing full-screen).
-
-Lastly, neither Telegram nor `tgcli` does not check mimetypes of the files you
-send for performance reasons. So, you might come across weird quirks if you
-send a file with a different types, such as an image having a play button, an
-audio that can be displayed full-screen etc.
-
-## Examples
-
-    # assuming you have TELEGRAM_BOT_TOKEN environment variable
-
-    # a regular message
-    tgcli bot send -r "123456" "My *markdown* message."
-
-    # an HTML-flavored message
-    tgcli bot send -r "123456" --format "html" "My <strong>HTML</strong> message."
-
-    # send file
-    export TELEGRAM_BOT_TOKEN="BotToken"
-    tgcli bot send -r "123456" -f "any.txt" "File description"
-
-    # send file as
-    tgcli bot send -r "123456" -f "any.png" --as "photo" "File description"

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -151,3 +151,28 @@ And it is even *safer to assume that bots' files will be higher priority in
 wiping operations*. That's why it is a good practice to forward the files sent
 by bots to *Saved Messages*, even better to backup them to a storage that you
 own if these files have higher importance to you.
+
+### poll
+
+`poll` is a subcommand of `send` and is used to publish polls. To get help:
+
+    tgcli bot send -r $RECEIVER_ID poll --help
+
+`poll` has the options and parameters below:
+
+Short Flag | Full Flag | Required/Optional | Description
+--- | --- | --- | ---
+-o | --option | Required[^2] | A single option for poll. You can define multiple options.
+ | question | Required | The question for poll.
+
+!!! warning
+    You cannot send polls to private chats but only to groups and channels.
+
+To publish a poll:
+
+    tgcli bot send -r $RECEIVER_ID poll "Am I a ghost?" -o "Yes" -o "No"
+
+!!! note
+    Also keep in mind the the order of `-o`/`--option` is preserved for polls.
+
+[^2]: You need to define at least two options for a valid poll.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+python_files =
+    test_*.py
+addopts = -s
+console_output_style = progress
+log_cli_level = DEBUG
+log_print = True

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     include_package_data=True,
     keywords="telegram messaging communication terminal tool cli",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: Apache Software License",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,168 @@
+import io
+import json
+
+import pytest
+import requests_mock
+
+import tgcli.request.bot
+
+
+@pytest.fixture
+def mock_adapter() -> requests_mock.Adapter:
+    """
+    Returns a mock adapter.
+    """
+    return requests_mock.Adapter()
+
+
+@pytest.fixture
+def bot_session(mock_adapter) -> tgcli.request.bot.BotSession:
+    """
+    Creates a bot session. It is mounted with a mock adapter.
+
+    Fixtures
+    --------
+    mock_adapter
+
+    Attributes
+    ----------
+    token = "0"
+    _is_mocked = True
+    """
+    session = tgcli.request.bot.BotSession("0")
+    session.mount("mock", mock_adapter)
+    session._is_mocked = True
+    return session
+
+
+@pytest.fixture
+def bot_request_factory(bot_session) -> callable:
+    """
+    Returns a factory that creates a bot request.
+
+    Fixtures
+    --------
+    bot_session
+    """
+
+    def factory(method_name: str) -> tgcli.request.bot.BotRequest:
+        return tgcli.request.bot.BotRequest(bot_session, method_name)
+
+    return factory
+
+
+@pytest.fixture
+def bot_authentication_request(
+    bot_session
+) -> tgcli.request.bot.AuthenticationRequest:
+    """
+    Returns a bot authentication request.
+
+    Fixtures
+    --------
+    bot_session
+
+    Attributes
+    ----------
+    session = bot_session
+    """
+    return tgcli.request.bot.AuthenticationRequest(bot_session)
+
+
+@pytest.fixture
+def bot_send_message_request(
+    bot_session
+) -> tgcli.request.bot.SendMessageRequest:
+    """
+    Returns a bot send message request.
+
+    Fixtures
+    --------
+    bot_session
+
+    Attributes
+    ----------
+    session = bot_session
+    chat_id = 1
+    text = "foo"
+    """
+    return tgcli.request.bot.SendMessageRequest(bot_session, 1, "foo")
+
+
+@pytest.fixture
+def bot_send_document_request_factory(bot_session) -> callable:
+    """
+    Returns a bot send document request factory.
+
+    Fixtures
+    --------
+    bot_session
+    """
+
+    def factory(
+        chat_id: int,
+        file: io.FileIO,
+        caption: str,
+        media_type: tgcli.request.bot.MediaType,
+    ) -> tgcli.request.bot.SendFileRequest:
+        return tgcli.request.bot.SendFileRequest(
+            bot_session, chat_id, file, caption, media_type
+        )
+
+    return factory
+
+
+@pytest.fixture
+def bot_send_document_request(
+    bot_send_document_request_factory, file_factory
+) -> tgcli.request.bot.SendFileRequest:
+    """
+    Returns a bot send document request.
+
+    Fixtures
+    --------
+    bot_send_document_request_factory
+
+    Attributes
+    ----------
+    session = bot_session
+    chat_id = 1
+    file = file object to "tests/resources/file.png"
+    caption = "lorem ipsum"
+    """
+    return bot_send_document_request_factory(
+        1,
+        file_factory("tests/resources/file.png"),
+        "lorem ipsum",
+        tgcli.request.bot.MediaType.DOCUMENT,
+    )
+
+
+@pytest.fixture
+def request_body_factory() -> callable:
+    """
+    Returns a factory which deserializes JSON body from JSON to dict.
+    """
+
+    def factory(request: requests_mock.request.requests.Request) -> dict:
+        return json.loads(request.body.decode("utf-8"))
+
+    return factory
+
+
+@pytest.fixture
+def file_factory(request):
+    """
+    Returns a factory which opens a file in rb mode and properly closes it.
+
+    Fixtures
+    --------
+    request - In order to use finalizer.
+    """
+
+    def factory(file_path: str) -> io.FileIO:
+        file = open(file_path, "rb")
+        request.addfinalizer(lambda: file.close())
+        return file
+
+    return factory

--- a/tests/test_request/test_bot.py
+++ b/tests/test_request/test_bot.py
@@ -1,6 +1,6 @@
-import requests_mock
-
 import tgcli.request.bot
+
+import requests_mock
 
 
 class TestBotSession:

--- a/tests/test_request/test_bot.py
+++ b/tests/test_request/test_bot.py
@@ -1,5 +1,4 @@
 import requests_mock
-
 import tgcli.request.bot
 
 
@@ -60,7 +59,7 @@ class TestAuthenticationRequest:
             )
 
         response = self.session.send(self.request)
-        assert response.json().get("ok") == True
+        assert response.json().get("ok")
 
     def test_found_result(self):
         with open(
@@ -72,7 +71,7 @@ class TestAuthenticationRequest:
 
         response = self.session.send(self.request)
         assert response.json().get("result").get("id") == 1
-        assert response.json().get("result").get("is_bot") == True
+        assert response.json().get("result").get("is_bot")
         assert response.json().get("result").get("first_name") == "FooBot"
         assert response.json().get("result").get("username") == "foobot"
 
@@ -96,7 +95,7 @@ class TestAuthenticationRequest:
             )
 
         response = self.session.send(self.request)
-        assert response.json().get("ok") == False
+        assert not response.json().get("ok")
 
     def test_notfound_error_code(self):
         with open(

--- a/tests/test_request/test_bot.py
+++ b/tests/test_request/test_bot.py
@@ -1,16 +1,14 @@
 import requests_mock
+
 import tgcli.request.bot
 
 
 class TestBotSession:
-    def setup_method(self):
-        self.session = tgcli.request.bot.BotSession("0")
+    def test_has_token(self, bot_session):
+        assert hasattr(bot_session, "token")
 
-    def test_has_token(self):
-        assert hasattr(self.session, "token")
-
-    def test_has_base_url(self):
-        assert hasattr(self.session, "base_url")
+    def test_has_base_url(self, bot_session):
+        assert hasattr(bot_session, "base_url")
 
 
 class TestBotRequest:
@@ -18,200 +16,201 @@ class TestBotRequest:
         self.session = tgcli.request.bot.BotSession("0")
         self.request = tgcli.request.bot.BotRequest(self.session, "getMe")
 
-    def test_url(self):
+    def test_url(self, bot_session, bot_request_factory):
+        bot_request = bot_request_factory("getMe")
         url = "{base_url}{method_name}".format(
-            base_url=self.session.base_url, method_name="getMe"
+            base_url=bot_session.base_url, method_name="getMe"
         )
-        assert self.request.url == url
+        assert bot_request.url == url
 
 
 class TestAuthenticationRequest:
-    def setup_method(self):
-        self.adapter = requests_mock.Adapter()
+    def test_url(self, bot_authentication_request):
+        assert bot_authentication_request.url[-5:] == "getMe"
 
-        self.session = tgcli.request.bot.BotSession("0")
-        self.session._is_mocked = True
-
-        self.request = tgcli.request.bot.AuthenticationRequest(self.session)
-
-        self.session.mount("mock", self.adapter)
-
-    def test_url(self):
-        assert self.request.url[-5:] == "getMe"
-
-    def test_found_status(self):
+    def test_found_status(
+        self, mock_adapter, bot_session, bot_authentication_request
+    ):
         with open(
             "tests/resources/responses/bot.TestAuthenticationRequest.1.json"
         ) as f:
-            self.adapter.register_uri(
-                "POST", self.request.url, text=f.read(), status_code=200
+            mock_adapter.register_uri(
+                "POST",
+                bot_authentication_request.url,
+                text=f.read(),
+                status_code=200,
             )
 
-        response = self.session.send(self.request)
+        response = bot_session.send(bot_authentication_request)
         assert response.status_code == 200
 
-    def test_found_ok(self):
+    def test_found_ok(
+        self, mock_adapter, bot_session, bot_authentication_request
+    ):
         with open(
             "tests/resources/responses/bot.TestAuthenticationRequest.1.json"
         ) as f:
-            self.adapter.register_uri(
-                "POST", self.request.url, text=f.read(), status_code=200
+            mock_adapter.register_uri(
+                "POST",
+                bot_authentication_request.url,
+                text=f.read(),
+                status_code=200,
             )
 
-        response = self.session.send(self.request)
+        response = bot_session.send(bot_authentication_request)
         assert response.json().get("ok")
 
-    def test_found_result(self):
+    def test_found_result(
+        self, mock_adapter, bot_session, bot_authentication_request
+    ):
         with open(
             "tests/resources/responses/bot.TestAuthenticationRequest.1.json"
         ) as f:
-            self.adapter.register_uri(
-                "POST", self.request.url, text=f.read(), status_code=200
+            mock_adapter.register_uri(
+                "POST",
+                bot_authentication_request.url,
+                text=f.read(),
+                status_code=200,
             )
 
-        response = self.session.send(self.request)
+        response = bot_session.send(bot_authentication_request)
         assert response.json().get("result").get("id") == 1
         assert response.json().get("result").get("is_bot")
         assert response.json().get("result").get("first_name") == "FooBot"
         assert response.json().get("result").get("username") == "foobot"
 
-    def test_notfound_status(self):
+    def test_notfound_status(
+        self, mock_adapter, bot_session, bot_authentication_request
+    ):
         with open(
             "tests/resources/responses/bot.TestAuthenticationRequest.2.json"
         ) as f:
-            self.adapter.register_uri(
-                "POST", self.request.url, text=f.read(), status_code=404
+            mock_adapter.register_uri(
+                "POST",
+                bot_authentication_request.url,
+                text=f.read(),
+                status_code=404,
             )
 
-        response = self.session.send(self.request)
+        response = bot_session.send(bot_authentication_request)
         assert response.status_code == 404
 
-    def test_notfound_ok(self):
+    def test_notfound_ok(
+        self, mock_adapter, bot_session, bot_authentication_request
+    ):
         with open(
             "tests/resources/responses/bot.TestAuthenticationRequest.2.json"
         ) as f:
-            self.adapter.register_uri(
-                "POST", self.request.url, text=f.read(), status_code=404
+            mock_adapter.register_uri(
+                "POST",
+                bot_authentication_request.url,
+                text=f.read(),
+                status_code=404,
             )
 
-        response = self.session.send(self.request)
+        response = bot_session.send(bot_authentication_request)
         assert not response.json().get("ok")
 
-    def test_notfound_error_code(self):
+    def test_notfound_error_code(
+        self, mock_adapter, bot_session, bot_authentication_request
+    ):
         with open(
             "tests/resources/responses/bot.TestAuthenticationRequest.2.json"
         ) as f:
-            self.adapter.register_uri(
-                "POST", self.request.url, text=f.read(), status_code=404
+            mock_adapter.register_uri(
+                "POST",
+                bot_authentication_request.url,
+                text=f.read(),
+                status_code=404,
             )
 
-        response = self.session.send(self.request)
+        response = bot_session.send(bot_authentication_request)
         assert response.json().get("error_code") == 404
 
-    def test_notfound_description(self):
+    def test_notfound_description(
+        self, mock_adapter, bot_session, bot_authentication_request
+    ):
         with open(
             "tests/resources/responses/bot.TestAuthenticationRequest.2.json"
         ) as f:
-            self.adapter.register_uri(
-                "POST", self.request.url, text=f.read(), status_code=404
+            mock_adapter.register_uri(
+                "POST",
+                bot_authentication_request.url,
+                text=f.read(),
+                status_code=404,
             )
 
-        response = self.session.send(self.request)
+        response = bot_session.send(bot_authentication_request)
         assert response.json().get("description") == "Not Found"
 
 
 class TestSendMessageRequest:
-    def setup_method(self):
-        self.adapter = requests_mock.Adapter()
+    def test_url(self, bot_send_message_request):
+        assert bot_send_message_request.url[-11:] == "sendMessage"
 
-        self.session = tgcli.request.bot.BotSession("0")
-        self.session._is_mocked = True
+    def test_request_body_chat_id(
+        self, bot_send_message_request, request_body_factory
+    ):
+        request_body = request_body_factory(bot_send_message_request)
+        assert request_body.get("chat_id") == 1
 
-        self.request = tgcli.request.bot.SendMessageRequest(
-            self.session, 1, "foo"
-        )
+    def test_request_body_text(
+        self, bot_send_message_request, request_body_factory
+    ):
+        request_body = request_body_factory(bot_send_message_request)
+        assert request_body.get("text") == "foo"
 
-        import json
-
-        self.request_body = json.loads(self.request.body.decode("utf-8"))
-        self.session.mount("mock", self.adapter)
-
-    def test_url(self):
-        assert self.request.url[-11:] == "sendMessage"
-
-    def test_request_body_chat_id(self):
-        assert self.request_body.get("chat_id") == 1
-
-    def test_request_body_text(self):
-        assert self.request_body.get("text") == "foo"
-
-    def test_request_body_parse_mode(self):
-        assert self.request_body.get("parse_mode") == "Markdown"
+    def test_request_body_parse_mode(
+        self, bot_send_message_request, request_body_factory
+    ):
+        request_body = request_body_factory(bot_send_message_request)
+        assert request_body.get("parse_mode") == "Markdown"
 
 
 class TestSendDocumentRequest:
-    def setup_method(self):
-        self.adapter = requests_mock.Adapter()
+    def test_default_url(self, bot_send_document_request):
+        assert bot_send_document_request.url[-12:] == "sendDocument"
 
-        self.session = tgcli.request.bot.BotSession("0")
-        self.session._is_mocked = True
-
-        self.file = open("tests/resources/file.png", "rb")
-        self.request = tgcli.request.bot.SendFileRequest(
-            self.session, 1, self.file, "lorem ipsum"
-        )
-        self.session.mount("mock", self.adapter)
-
-    def teardown_method(self):
-        self.file.close()
-
-    def test_default_url(self):
-        assert self.request.url[-12:] == "sendDocument"
-
-    def test_photo_url(self):
-        session = tgcli.request.bot.BotSession("0")
-        request = tgcli.request.bot.SendFileRequest(
-            self.session,
+    def test_photo_url(self, bot_send_document_request_factory, file_factory):
+        request = bot_send_document_request_factory(
             1,
-            self.file,
+            file_factory("tests/resources/file.png"),
             "lorem ipsum",
             tgcli.request.bot.MediaType.PHOTO,
         )
         assert request.url[-9:] == "sendPhoto"
 
-    def test_audio_url(self):
-        session = tgcli.request.bot.BotSession("0")
-        request = tgcli.request.bot.SendFileRequest(
-            self.session,
+    def test_audio_url(self, bot_send_document_request_factory, file_factory):
+        request = bot_send_document_request_factory(
             1,
-            self.file,
+            file_factory("tests/resources/file.png"),
             "lorem ipsum",
             tgcli.request.bot.MediaType.AUDIO,
         )
         assert request.url[-9:] == "sendAudio"
 
-    def test_video_url(self):
-        session = tgcli.request.bot.BotSession("0")
-        request = tgcli.request.bot.SendFileRequest(
-            self.session,
+    def test_video_url(self, bot_send_document_request_factory, file_factory):
+        request = bot_send_document_request_factory(
             1,
-            self.file,
+            file_factory("tests/resources/file.png"),
             "lorem ipsum",
             tgcli.request.bot.MediaType.VIDEO,
         )
         assert request.url[-9:] == "sendVideo"
 
-    def test_request_body_chat_id(self):
-        assert b"chat_id" in self.request.body
+    def test_request_body_chat_id(self, bot_send_document_request):
+        assert b"chat_id" in bot_send_document_request.body
 
-    def test_request_body_caption(self):
-        assert b"caption" in self.request.body
+    def test_request_body_caption(self, bot_send_document_request):
+        assert b"caption" in bot_send_document_request.body
 
-    def test_request_body_parse_mode(self):
-        assert b"parse_mode" in self.request.body
+    def test_request_body_parse_mode(self, bot_send_document_request):
+        assert b"parse_mode" in bot_send_document_request.body
 
-    def test_request_body_disable_notification(self):
-        assert b"disable_notification" in self.request.body
+    def test_request_body_disable_notification(
+        self, bot_send_document_request
+    ):
+        assert b"disable_notification" in bot_send_document_request.body
 
-    def test_request_body_document(self):
-        assert b'filename="file.png"' in self.request.body
+    def test_request_body_document(self, bot_send_document_request):
+        assert b'filename="file.png"' in bot_send_document_request.body

--- a/tgcli/__init__.py
+++ b/tgcli/__init__.py
@@ -1,2 +1,2 @@
 __author__ = "Eray Erdin"
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/tgcli/__init__.py
+++ b/tgcli/__init__.py
@@ -1,2 +1,2 @@
 __author__ = "Eray Erdin"
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/tgcli/cli.py
+++ b/tgcli/cli.py
@@ -1,14 +1,13 @@
 import io
 import platform
-
 import sys
-import colorful
+
 import click
+import colorful
 import yaspin
 import yaspin.spinners
 
 import tgcli.request.bot
-
 
 IS_DARWIN = platform.system().lower() == "darwin"
 

--- a/tgcli/request/bot.py
+++ b/tgcli/request/bot.py
@@ -1,6 +1,7 @@
 import enum
 import io
 import typing
+
 import requests
 
 


### PR DESCRIPTION
### Added
 - `poll` section to *Bot* documentation

### Changed
 - `send` is now a group type of command which has `message`, `file` and `poll`
 subcommands.
 - Moved file sending functionality from `send` to `send file`
 - Moved message sending functionality from `send` to `send message`
 - `send` now only takes receiver chat id, other subcommands take related
 options and parameters
 - Updated *Bot* section of documentation