### PR TITLE
Seperated File Subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - `bot send photo` subcommand
+ - `bot send video` subcommand
+ - `bot send audio` subcommand
+
 ### Changed
  - `bot send file` subcommand to `bot send document`
  - `bot send document` only sends *any* type of data
+
+### Removed
+ - `bot send file` subcommand
 
 ## [v0.2.1] - 2019-04-20
 ### Added

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -192,6 +192,29 @@ The usage is similar to the usage of [document](bot.md#document).
 
 [issue_27]: https://github.com/erayerdin/tgcli/issues/27
 
+### audio
+
+`audio` is a subcommand of `send` and is used to send audios
+through `tgcli`. To get help:
+
+    tgcli bot send -r $RECEIVER_ID audio --help
+
+!!! info
+    A file sent by `audio` subcommand **can be played** *with a
+    play button*.
+
+`audio` has the options and parameters below:
+
+Short Flag | Full Flag | Required/Optional | Description
+--- | --- | --- | ---
+-m | --message | Optional | The message.
+ | --format | Optional | The format of message. Choices are `markdown` and `html`. Default is `markdown`.
+ | --performer | Optional | The performer of audio.
+ | --title | Optional | The title of audio.
+ | file | Required | Path to file.
+
+The usage is similar to the usage of [document](bot.md#document).
+
 ### poll
 
 `poll` is a subcommand of `send` and is used to publish polls. To get help:

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -96,7 +96,13 @@ In order to send a message, do:
 `document` is a subcommand of `send` and is used to send files through `tgcli`. To
 get help:
 
-tgcli bot send -r $RECEIVER_ID file --help
+    tgcli bot send -r $RECEIVER_ID file --help
+
+!!! Warning
+    A file sent by `document` subcommand is *only
+    downloadable*, which means it will not have traits of several
+    media types in Telegram such as play button, full-screen view
+    or keyboard navigation etc.
 
 `document` has the options and parameters below:
 
@@ -130,6 +136,61 @@ And it is even *safer to assume that bots' files will be higher priority in
 wiping operations*. That's why it is a good practice to forward the files sent
 by bots to *Saved Messages*, even better to backup them to a storage that you
 own if these files have higher importance to you.
+
+### photo
+
+`photo` is a subcommand of `send` and is used to send photos
+through `tgcli`. To get help:
+
+    tgcli bot send -r $RECEIVER_ID photo --help
+
+!!! info
+    A file sent by `photo` subcommand (i) can be viewed
+    **full-screen** *with one click/touch* and (ii) is
+    **can be navigated** *with arrow keys on the keyboard or
+    swiping*.
+
+`photo` has the options and parameters below:
+
+Short Flag | Full Flag | Required/Optional | Description
+--- | --- | --- | ---
+-m | --message | Optional | The message.
+ | --format | Optional | The format of message. Choices are `markdown` and `html`. Default is `markdown`.
+ | file | Required | Path to file.
+
+The usage is similar to the usage of [document](bot.md#document).
+
+### video
+
+`video` is a subcommand of `send` and is used to send videos
+through `tgcli`. To get help:
+
+    tgcli bot send -r $RECEIVER_ID video --help
+
+!!! info
+    A file sent by `video` subcommand can be viewed
+    **full-screen** *with a button*.
+
+`video` has the options and parameters below:
+
+Short Flag | Full Flag | Required/Optional | Description
+--- | --- | --- | ---
+-m | --message | Optional | The message.
+ | --format | Optional | The format of message. Choices are `markdown` and `html`. Default is `markdown`.
+-h | --horizontal | Optional | The horizontal aspect ratio of video.
+-v | --vertical | Optional | The vertical aspect ratio of video.
+ | file | Required | Path to file.
+
+The usage is similar to the usage of [document](bot.md#document).
+
+!!! warning
+    Telegram server assumes the aspect ratio of video as 1:1
+    for thumbnail due to performance reasons. See
+    [this issue][issue_27] for an example. That's why it is good
+    to know the aspect ratio of the video beforehand. Standards
+    are `16:9` for new videos and `4:3` for old videos.
+
+[issue_27]: https://github.com/erayerdin/tgcli/issues/27
 
 ### poll
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -164,8 +164,8 @@ def bot_send_document_request(
     thumbnail = file object to "tests/resources/file.png" or request.param
     caption = "lorem ipsum"
     """
-    thumbnail = getattr(
-        request, "param", file_factory("tests/resources/file.png")
+    thumbnail = getattr(request, "param", dict()).get(
+        "thumbnail", file_factory("tests/resources/file.png")
     )
     return tgcli.request.bot.SendDocumentRequest(
         bot_session,
@@ -220,14 +220,16 @@ def bot_send_audio_request(
     audio = file object to "tests/resources/file.png"
     caption = "lorem ipsum"
     duration = None or request.param
-    performer = "Slipknot"
-    title = "People=Shit"
+    performer = "Slipknot" or request.param
+    title = "People=Shit" or request.param
     thumbnail = file object to "tests/resources/file.png"
     """
-    thumbnail = getattr(
-        request, "param", (file_factory("tests/resources/file.png"), None)
-    )[0]
-    duration = getattr(request, "param", (None, None))[1]
+    thumbnail = getattr(request, "param", dict()).get(
+        "thumbnail", file_factory("tests/resources/file.png")
+    )
+    duration = getattr(request, "param", dict()).get("duration", None)
+    performer = getattr(request, "param", dict()).get("performer", "Slipknot")
+    title = getattr(request, "param", dict()).get("title", "People=Shit")
     return tgcli.request.bot.SendAudioRequest(
         bot_session,
         1,
@@ -235,8 +237,8 @@ def bot_send_audio_request(
         thumbnail,
         "lorem ipsum",
         duration,
-        performer="Slipknot",
-        title="People=Shit",
+        performer=performer,
+        title=title,
     )
 
 
@@ -261,13 +263,15 @@ def bot_send_video_request(
     thumbnail = file object to "tests/resources/file.png"
     caption = "lorem ipsum"
     duration = None or request.param
-    width = 640
-    height = 480
+    width = 640 or request.param
+    height = 480 or request.param
     """
-    thumbnail = getattr(
-        request, "param", (file_factory("tests/resources/file.png"), None)
-    )[0]
-    duration = getattr(request, "param", (None, None))[1]
+    thumbnail = getattr(request, "param", dict()).get(
+        "thumbnail", file_factory("tests/resources/file.png")
+    )
+    duration = getattr(request, "param", dict()).get("duration", None)
+    width = getattr(request, "param", dict()).get("width", 640)
+    height = getattr(request, "param", dict()).get("height", 480)
     return tgcli.request.bot.SendVideoRequest(
         bot_session,
         1,
@@ -275,8 +279,8 @@ def bot_send_video_request(
         thumbnail,
         "lorem ipsum",
         duration,
-        width=640,
-        height=480,
+        width=width,
+        height=height,
     )
 
 

--- a/tests/test_request/test_bot.py
+++ b/tests/test_request/test_bot.py
@@ -176,13 +176,13 @@ class TestSendDocumentRequest(BaseSendFileTest):
         assert bot_send_document_request.url[-12:] == "sendDocument"
 
     def test_request_body_thumbnail(self, bot_send_document_request):
-        assert b'name="thumbnail"' in bot_send_document_request.body
+        assert b'name="thumb"' in bot_send_document_request.body
 
     @pytest.mark.parametrize(
         "bot_send_document_request", ({"thumbnail": None},), indirect=True
     )
     def test_request_body_without_thumbnail(self, bot_send_document_request):
-        assert b'name="thumbnail"' not in bot_send_document_request.body
+        assert b'name="thumb"' not in bot_send_document_request.body
 
 
 class TestSendPhotoRequest(BaseSendFileTest):
@@ -199,13 +199,13 @@ class TestSendAudioRequest(BaseSendFileTest):
         assert bot_send_audio_request.url[-9:] == "sendAudio"
 
     def test_request_body_thumbnail(self, bot_send_audio_request):
-        assert b'name="thumbnail"' in bot_send_audio_request.body
+        assert b'name="thumb"' in bot_send_audio_request.body
 
     @pytest.mark.parametrize(
         "bot_send_audio_request", ({"thumbnail": None},), indirect=True
     )
     def test_request_body_without_thumbnail(self, bot_send_audio_request):
-        assert b'name="thumbnail"' not in bot_send_audio_request.body
+        assert b'name="thumb"' not in bot_send_audio_request.body
 
     @pytest.mark.parametrize(
         "bot_send_audio_request", ({"duration": 1},), indirect=True
@@ -269,13 +269,13 @@ class TestSendVideoRequest(BaseSendFileTest):
         assert b'name="duration"' not in bot_send_video_request.body
 
     def test_request_body_thumbnail(self, bot_send_video_request):
-        assert b'name="thumbnail"' in bot_send_video_request.body
+        assert b'name="thumb"' in bot_send_video_request.body
 
     @pytest.mark.parametrize(
         "bot_send_video_request", ({"thumbnail": None},), indirect=True
     )
     def test_request_body_without_thumbnail(self, bot_send_video_request):
-        assert b'name="thumbnail"' not in bot_send_video_request.body
+        assert b'name="thumb"' not in bot_send_video_request.body
 
 
 class TestSendPollRequest:

--- a/tests/test_request/test_bot.py
+++ b/tests/test_request/test_bot.py
@@ -179,7 +179,7 @@ class TestSendDocumentRequest(BaseSendFileTest):
         assert b'name="thumbnail"' in bot_send_document_request.body
 
     @pytest.mark.parametrize(
-        "bot_send_document_request", (None,), indirect=True
+        "bot_send_document_request", ({"thumbnail": None},), indirect=True
     )
     def test_request_body_without_thumbnail(self, bot_send_document_request):
         assert b'name="thumbnail"' not in bot_send_document_request.body
@@ -202,13 +202,13 @@ class TestSendAudioRequest(BaseSendFileTest):
         assert b'name="thumbnail"' in bot_send_audio_request.body
 
     @pytest.mark.parametrize(
-        "bot_send_audio_request", ((None, 1),), indirect=True
+        "bot_send_audio_request", ({"thumbnail": None},), indirect=True
     )
     def test_request_body_without_thumbnail(self, bot_send_audio_request):
         assert b'name="thumbnail"' not in bot_send_audio_request.body
 
     @pytest.mark.parametrize(
-        "bot_send_audio_request", ((None, 1),), indirect=True
+        "bot_send_audio_request", ({"duration": 1},), indirect=True
     )
     def test_request_body_duration(self, bot_send_audio_request):
         assert b'name="duration"' in bot_send_audio_request.body
@@ -219,8 +219,20 @@ class TestSendAudioRequest(BaseSendFileTest):
     def test_request_body_performer(self, bot_send_audio_request):
         assert b'name="performer"' in bot_send_audio_request.body
 
+    @pytest.mark.parametrize(
+        "bot_send_audio_request", ({"performer": None},), indirect=True
+    )
+    def test_request_body_without_performer(self, bot_send_audio_request):
+        assert b'name="performer"' not in bot_send_audio_request.body
+
     def test_request_body_title(self, bot_send_audio_request):
         assert b'name="title"' in bot_send_audio_request.body
+
+    @pytest.mark.parametrize(
+        "bot_send_audio_request", ({"title": None},), indirect=True
+    )
+    def test_request_body_without_title(self, bot_send_audio_request):
+        assert b'name="title"' not in bot_send_audio_request.body
 
 
 class TestSendVideoRequest(BaseSendFileTest):
@@ -232,23 +244,35 @@ class TestSendVideoRequest(BaseSendFileTest):
     def test_request_body_width(self, bot_send_video_request):
         assert b'name="width"' in bot_send_video_request.body
 
+    @pytest.mark.parametrize(
+        "bot_send_video_request", ({"width": None},), indirect=True
+    )
+    def test_request_body_without_width(self, bot_send_video_request):
+        assert b'name="width"' not in bot_send_video_request.body
+
     def test_request_body_height(self, bot_send_video_request):
         assert b'name="height"' in bot_send_video_request.body
 
     @pytest.mark.parametrize(
-        "bot_send_video_request", ((None, 1),), indirect=True
+        "bot_send_video_request", ({"height": None},), indirect=True
+    )
+    def test_request_body_without_height(self, bot_send_video_request):
+        assert b'name="height"' not in bot_send_video_request.body
+
+    @pytest.mark.parametrize(
+        "bot_send_video_request", ({"duration": 1},), indirect=True
     )
     def test_request_body_duration(self, bot_send_video_request):
-        assert b"duration" in bot_send_video_request.body
+        assert b'name="duration"' in bot_send_video_request.body
 
     def test_request_body_without_duration(self, bot_send_video_request):
-        assert b"duration" not in bot_send_video_request.body
+        assert b'name="duration"' not in bot_send_video_request.body
 
     def test_request_body_thumbnail(self, bot_send_video_request):
         assert b'name="thumbnail"' in bot_send_video_request.body
 
     @pytest.mark.parametrize(
-        "bot_send_video_request", ((None, None),), indirect=True
+        "bot_send_video_request", ({"thumbnail": None},), indirect=True
     )
     def test_request_body_without_thumbnail(self, bot_send_video_request):
         assert b'name="thumbnail"' not in bot_send_video_request.body

--- a/tgcli/cli.py
+++ b/tgcli/cli.py
@@ -203,3 +203,23 @@ def document(
     file.close()
 
     send_message(session, request)
+
+
+@send.command()
+@click.option(
+    "-m", "--message", default="", help="The message to inline with file."
+)
+@FORMAT_OPTION
+@click.argument("file", type=click.File("rb"), required=True)
+@click.pass_context
+def photo(ctx, message: str, format: str, file: io.BytesIO):
+    session = tgcli.request.bot.BotSession(ctx.obj["token"])
+    session.verify = ctx.obj["secure"]
+    receiver = ctx.obj["receiver"]
+
+    request = tgcli.request.bot.SendPhotoRequest(
+        session, receiver, file, message, MESSAGE_FORMATS[format]
+    )
+    file.close()
+
+    send_message(session, request)

--- a/tgcli/cli.py
+++ b/tgcli/cli.py
@@ -223,3 +223,49 @@ def photo(ctx, message: str, format: str, file: io.BytesIO):
     file.close()
 
     send_message(session, request)
+
+
+DURATION_OPTION = click.option(
+    "--duration", type=click.INT, help="The duration by seconds."
+)
+
+
+@send.command()
+@click.option(
+    "-m", "--message", default="", help="The message to inline with file."
+)
+@FORMAT_OPTION
+@DURATION_OPTION
+@THUMBNAIL_OPTION
+@click.option("-w", "--width", type=click.INT, help="The width of video.")
+@click.option("-h", "--height", type=click.INT, help="The height of video.")
+@click.argument("file", type=click.File("rb"), required=True)
+@click.pass_context
+def video(
+    ctx,
+    message: str,
+    format: str,
+    duration: int,
+    width: int,
+    height: int,
+    thumbnail: io.BytesIO,
+    file: io.BytesIO,
+):
+    session = tgcli.request.bot.BotSession(ctx.obj["token"])
+    session.verify = ctx.obj["secure"]
+    receiver = ctx.obj["receiver"]
+
+    request = tgcli.request.bot.SendVideoRequest(
+        session,
+        receiver,
+        file,
+        thumbnail,
+        message,
+        duration,
+        width,
+        height,
+        MESSAGE_FORMATS[format],
+    )
+    file.close()
+
+    send_message(session, request)

--- a/tgcli/cli.py
+++ b/tgcli/cli.py
@@ -272,3 +272,40 @@ def video(
     file.close()
 
     send_message(session, request)
+
+
+@send.command()
+@click.option(
+    "-m", "--message", default="", help="The message to inline with file."
+)
+@FORMAT_OPTION
+@click.option("--performer", help="The performer of audio.")
+@click.option("--title", help="The title of audio.")
+@FILE_ARGUMENT
+@click.pass_context
+def audio(
+    ctx,
+    message: str,
+    format: str,
+    performer: str,
+    title: str,
+    file: io.BytesIO,
+):
+    session = tgcli.request.bot.BotSession(ctx.obj["token"])
+    session.verify = ctx.obj["secure"]
+    receiver = ctx.obj["receiver"]
+
+    request = tgcli.request.bot.SendAudioRequest(
+        session,
+        receiver,
+        file,
+        None,
+        message,
+        None,
+        performer,
+        title,
+        MESSAGE_FORMATS[format],
+    )
+    file.close()
+
+    send_message(session, request)

--- a/tgcli/cli.py
+++ b/tgcli/cli.py
@@ -5,9 +5,10 @@ import typing
 
 import click
 import colorful
-import tgcli.request.bot
 import yaspin
 import yaspin.spinners
+
+import tgcli.request.bot
 
 IS_DARWIN = platform.system().lower() == "darwin"
 
@@ -180,6 +181,7 @@ def location(ctx, latitude: float, longitude: float):
 
 
 THUMBNAIL_OPTION = click.option("--thumbnail", type=click.File("rb"))
+FILE_ARGUMENT = click.argument("file", type=click.File("rb"), required=True)
 
 
 @send.command()
@@ -188,7 +190,7 @@ THUMBNAIL_OPTION = click.option("--thumbnail", type=click.File("rb"))
 )
 @THUMBNAIL_OPTION
 @FORMAT_OPTION
-@click.argument("file", type=click.File("rb"), required=True)
+@FILE_ARGUMENT
 @click.pass_context
 def document(
     ctx, message: str, thumbnail: io.BytesIO, format: str, file: io.BytesIO
@@ -210,7 +212,7 @@ def document(
     "-m", "--message", default="", help="The message to inline with file."
 )
 @FORMAT_OPTION
-@click.argument("file", type=click.File("rb"), required=True)
+@FILE_ARGUMENT
 @click.pass_context
 def photo(ctx, message: str, format: str, file: io.BytesIO):
     session = tgcli.request.bot.BotSession(ctx.obj["token"])
@@ -225,30 +227,31 @@ def photo(ctx, message: str, format: str, file: io.BytesIO):
     send_message(session, request)
 
 
-DURATION_OPTION = click.option(
-    "--duration", type=click.INT, help="The duration by seconds."
-)
-
-
 @send.command()
 @click.option(
     "-m", "--message", default="", help="The message to inline with file."
 )
 @FORMAT_OPTION
-@DURATION_OPTION
-@THUMBNAIL_OPTION
-@click.option("-w", "--width", type=click.INT, help="The width of video.")
-@click.option("-h", "--height", type=click.INT, help="The height of video.")
-@click.argument("file", type=click.File("rb"), required=True)
+@click.option(
+    "-h",
+    "--horizontal",
+    type=click.INT,
+    help="The horizontal aspect ratio of video.",
+)
+@click.option(
+    "-v",
+    "--vertical",
+    type=click.INT,
+    help="The vertical aspect ratio of video.",
+)
+@FILE_ARGUMENT
 @click.pass_context
 def video(
     ctx,
     message: str,
     format: str,
-    duration: int,
-    width: int,
-    height: int,
-    thumbnail: io.BytesIO,
+    horizontal: int,
+    vertical: int,
     file: io.BytesIO,
 ):
     session = tgcli.request.bot.BotSession(ctx.obj["token"])
@@ -259,11 +262,11 @@ def video(
         session,
         receiver,
         file,
-        thumbnail,
+        None,
         message,
-        duration,
-        width,
-        height,
+        None,
+        horizontal,
+        vertical,
         MESSAGE_FORMATS[format],
     )
     file.close()

--- a/tgcli/request/bot.py
+++ b/tgcli/request/bot.py
@@ -228,8 +228,8 @@ class SendAudioRequest(BaseFileRequest):
         thumbnail: io.BytesIO = None,
         caption: str = "",
         duration: int = None,
-        performer: str = "",
-        title: str = "",
+        performer: str = None,
+        title: str = None,
         parse_mode: str = "Markdown",
         disable_notification: bool = False,
     ):
@@ -241,12 +241,16 @@ class SendAudioRequest(BaseFileRequest):
             "caption": caption,
             "parse_mode": parse_mode,
             "disable_notification": disable_notification,
-            "performer": str(performer),
-            "title": str(title),
             "media_type": MediaType.AUDIO,
         }
         if duration is not None:
             payload["duration"] = int(duration)
+
+        if performer is not None:
+            payload["performer"] = str(performer)
+
+        if title is not None:
+            payload["title"] = str(title)
 
         if thumbnail:
             super().__init__(**payload, **extra_files)

--- a/tgcli/request/bot.py
+++ b/tgcli/request/bot.py
@@ -181,7 +181,7 @@ class SendDocumentRequest(BaseFileRequest):
         parse_mode: str = "Markdown",
         disable_notification: bool = False,
     ):
-        extra_files = {"thumbnail": thumbnail}
+        extra_files = {"thumb": thumbnail}
         payload = {
             "session": session,
             "chat_id": chat_id,
@@ -233,7 +233,7 @@ class SendAudioRequest(BaseFileRequest):
         parse_mode: str = "Markdown",
         disable_notification: bool = False,
     ):
-        extra_files = {"thumbnail": thumbnail}
+        extra_files = {"thumb": thumbnail}
         payload = {
             "session": session,
             "chat_id": chat_id,
@@ -272,7 +272,7 @@ class SendVideoRequest(BaseFileRequest):
         parse_mode: str = "Markdown",
         disable_notification: bool = False,
     ):
-        extra_files = {"thumbnail": thumbnail}
+        extra_files = {"thumb": thumbnail}
         payload = {
             "session": session,
             "chat_id": chat_id,


### PR DESCRIPTION
Now there's no `file` subcommand. It has many below:

 - `document`
 - `photo`
 - `video`
 - `audio`