### PR TITLE
Silent Argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+ - `send --silent` global argument helps you to supress notification sound on the target device.
+
 ## [v0.5.0-alpha.4] - 2021-11-23
 ### Added
  - `bot send poll` has been implemented.

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -50,6 +50,7 @@ operations. To get help:
 | ---------- | ---------- | ----------------- | ------------ | --------------------------------------------------------------------------------------------------------- |
 | -r         | --receiver | Required          | Global       | The receiver's ID, an integer.                                                                            |
 |            | --format   | Optional          | Global       | The format of message. Choices are `markdown` and `html`. Default is `markdown`.[^markdown_format_choice] |
+|            | --silent   | Optional          | Global       | The message will not play notification sound on target device if present.                                 |
 
 After you define the receiver's ID, then you can use any subcommand of `send`. To give an example:
 

--- a/docs/bot.md
+++ b/docs/bot.md
@@ -60,10 +60,19 @@ tgcli bot send message "Hello, world!" -r 1234
 # or --receiver
 ```
 
-[^markdown_format_choice]: By default, [MarkdownV2](https://core.telegram.org/bots/api#markdownv2-style) style is used.
-
 !!! tip
     ID of a user  *is not* username or human-readable name. It is an unsigned 64-bit integer representing the account. To get your ID, send [@userinfobot](https://t.me/userinfobot) *any* message and it will provide you *your own* user id.
+
+If you'd like to send a message without the notification sound playing on the target device, you can use `--silent` global argument to supress the sound.
+
+```bash
+tgcli bot send message "foo" -r 1234 --silent
+```
+
+!!! warning
+    `--silent` argument does not disable notification, it only supresses the notification sound. The user will still see the notification on device *unless the user willingly disabled the notifications from your bot*.
+
+[^markdown_format_choice]: By default, [MarkdownV2](https://core.telegram.org/bots/api#markdownv2-style) style is used.
 
 ### message
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,8 +8,7 @@ use clap::{
 use crate::{
     cli::validators::{
         audio_validator, caption_validator, file_validator, float_validator, image_validator,
-        poll_option_validator, poll_question_validator, positive_integer_validator,
-        video_validator,
+        poll_option_validator, poll_question_validator, video_validator,
     },
     operations::{
         bot::send::{
@@ -60,15 +59,6 @@ pub fn get_app() -> App<'static, 'static> {
             AppSettings::DeriveDisplayOrder,
         ])
         .settings(&[AppSettings::SubcommandRequiredElseHelp])
-        .args(&[
-            Arg::with_name("secure")
-                .long("secure")
-                .help("To provide secure connection. This is the default behavior.")
-                .conflicts_with("no-secure"),
-            Arg::with_name("no-secure")
-                .long("no-secure")
-                .help(r#"Reverse of "secure" flag."#),
-        ])
         .subcommands(vec![SubCommand::with_name("bot")
             .settings(&[AppSettings::SubcommandRequiredElseHelp])
             .about("Operations for bots.")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -62,23 +62,17 @@ pub fn get_app() -> App<'static, 'static> {
         .subcommands(vec![SubCommand::with_name("bot")
             .settings(&[AppSettings::SubcommandRequiredElseHelp])
             .about("Operations for bots.")
-            .args(&[
-                Arg::with_name("token")
-                    .long("token")
-                    .short("t")
-                    .help("Telegram bot token.")
-                    .takes_value(true)
-                    // an arg cannot be global and required at the same time for some reason
-                    // REF https://github.com/clap-rs/clap/issues/1546
-                    // .required(true)
-                    .env("TELEGRAM_BOT_TOKEN")
-                    .hide_env_values(true)
-                    .global(true),
-                Arg::with_name("no-notify")
-                    .long("no-notify")
-                    .takes_value(false)
-                    .help("Will not send notification to the user if present."),
-            ])
+            .args(&[Arg::with_name("token")
+                .long("token")
+                .short("t")
+                .help("Telegram bot token.")
+                .takes_value(true)
+                // an arg cannot be global and required at the same time for some reason
+                // REF https://github.com/clap-rs/clap/issues/1546
+                // .required(true)
+                .env("TELEGRAM_BOT_TOKEN")
+                .hide_env_values(true)
+                .global(true)])
             .subcommands(vec![SubCommand::with_name("send")
                 .settings(&[AppSettings::SubcommandRequiredElseHelp])
                 .about("Sending operations for bots.")
@@ -99,6 +93,10 @@ pub fn get_app() -> App<'static, 'static> {
                         .possible_values(&["markdown", "html"])
                         .default_value("markdown")
                         .global(true),
+                    Arg::with_name("no-notify")
+                        .long("no-notify")
+                        .takes_value(false)
+                        .help("Will not send notification to the user if present."),
                 ])
                 .subcommands(vec![
                     SubCommand::with_name("message")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -93,8 +93,8 @@ pub fn get_app() -> App<'static, 'static> {
                         .possible_values(&["markdown", "html"])
                         .default_value("markdown")
                         .global(true),
-                    Arg::with_name("no-notify")
-                        .long("no-notify")
+                    Arg::with_name("silent")
+                        .long("silent")
                         .takes_value(false)
                         .global(true)
                         .help("Will send a silent notification to the user if present."),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -72,17 +72,23 @@ pub fn get_app() -> App<'static, 'static> {
         .subcommands(vec![SubCommand::with_name("bot")
             .settings(&[AppSettings::SubcommandRequiredElseHelp])
             .about("Operations for bots.")
-            .args(&[Arg::with_name("token")
-                .long("token")
-                .short("t")
-                .help("Telegram bot token.")
-                .takes_value(true)
-                // an arg cannot be global and required at the same time for some reason
-                // REF https://github.com/clap-rs/clap/issues/1546
-                // .required(true)
-                .env("TELEGRAM_BOT_TOKEN")
-                .hide_env_values(true)
-                .global(true)])
+            .args(&[
+                Arg::with_name("token")
+                    .long("token")
+                    .short("t")
+                    .help("Telegram bot token.")
+                    .takes_value(true)
+                    // an arg cannot be global and required at the same time for some reason
+                    // REF https://github.com/clap-rs/clap/issues/1546
+                    // .required(true)
+                    .env("TELEGRAM_BOT_TOKEN")
+                    .hide_env_values(true)
+                    .global(true),
+                Arg::with_name("no-notify")
+                    .long("no-notify")
+                    .takes_value(false)
+                    .help("Will not send notification to the user if present."),
+            ])
             .subcommands(vec![SubCommand::with_name("send")
                 .settings(&[AppSettings::SubcommandRequiredElseHelp])
                 .about("Sending operations for bots.")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -96,7 +96,8 @@ pub fn get_app() -> App<'static, 'static> {
                     Arg::with_name("no-notify")
                         .long("no-notify")
                         .takes_value(false)
-                        .help("Will not send notification to the user if present."),
+                        .global(true)
+                        .help("Will send a silent notification to the user if present."),
                 ])
                 .subcommands(vec![
                     SubCommand::with_name("message")

--- a/src/convert/operations/bot/send/mod.rs
+++ b/src/convert/operations/bot/send/mod.rs
@@ -71,9 +71,9 @@ impl TryFrom<ArgMatches<'static>> for SendParams {
             }
         };
 
-        let no_notify = m.is_present("no-notify");
+        let silent = m.is_present("silent");
 
-        let params = SendParams::new(receiver, MessageFormat::from(format), no_notify);
+        let params = SendParams::new(receiver, MessageFormat::from(format), silent);
         trace!("send params: {:?}", params);
         Ok(params)
     }

--- a/src/convert/operations/bot/send/mod.rs
+++ b/src/convert/operations/bot/send/mod.rs
@@ -71,7 +71,9 @@ impl TryFrom<ArgMatches<'static>> for SendParams {
             }
         };
 
-        let params = SendParams::new(receiver, MessageFormat::from(format));
+        let no_notify = m.is_present("no-notify");
+
+        let params = SendParams::new(receiver, MessageFormat::from(format), no_notify);
         trace!("send params: {:?}", params);
         Ok(params)
     }

--- a/src/http/request/models/sendaudio.rs
+++ b/src/http/request/models/sendaudio.rs
@@ -31,6 +31,7 @@ pub struct SendAudioRequestModel {
     title: Option<String>,
     caption: Option<String>,
     parse_mode: ParseMode,
+    disable_notification: bool,
 }
 
 impl TryFrom<SendAudioRequestModel> for Form {
@@ -75,7 +76,12 @@ impl TryFrom<SendAudioRequestModel> for Form {
             None => performer_form,
         };
 
-        Ok(title_form)
+        let notification_form = match m.disable_notification {
+            true => title_form.text("disable_notification", "true"),
+            false => title_form,
+        };
+
+        Ok(notification_form)
     }
 }
 
@@ -98,6 +104,7 @@ impl From<SendAudioParams> for SendAudioRequestModel {
         let audio = InputFile::Local(params.3.file);
         let performer = params.3.performer;
         let title = params.3.title;
+        let disable_notification = params.2.no_notify;
 
         SendAudioRequestModel {
             chat_id,
@@ -106,6 +113,7 @@ impl From<SendAudioParams> for SendAudioRequestModel {
             audio,
             performer,
             title,
+            disable_notification,
         }
     }
 }

--- a/src/http/request/models/sendaudio.rs
+++ b/src/http/request/models/sendaudio.rs
@@ -104,7 +104,7 @@ impl From<SendAudioParams> for SendAudioRequestModel {
         let audio = InputFile::Local(params.3.file);
         let performer = params.3.performer;
         let title = params.3.title;
-        let disable_notification = params.2.no_notify;
+        let disable_notification = params.2.silent;
 
         SendAudioRequestModel {
             chat_id,

--- a/src/http/request/models/senddocument.rs
+++ b/src/http/request/models/senddocument.rs
@@ -31,6 +31,7 @@ pub struct SendDocumentRequestModel {
     thumbnail: Option<InputFile>,
     caption: Option<String>,
     parse_mode: ParseMode,
+    disable_notification: bool,
 }
 
 impl TryFrom<SendDocumentRequestModel> for Form {
@@ -81,7 +82,12 @@ impl TryFrom<SendDocumentRequestModel> for Form {
             None => document_form,
         };
 
-        Ok(thumbnail_form)
+        let notification_form = match m.disable_notification {
+            true => thumbnail_form.text("disable_notification", "true"),
+            false => thumbnail_form,
+        };
+
+        Ok(notification_form)
     }
 }
 
@@ -108,12 +114,15 @@ impl From<SendDocumentParams> for SendDocumentRequestModel {
             None => None,
         };
 
+        let disable_notification = params.2.silent;
+
         SendDocumentRequestModel {
             chat_id,
             caption,
             parse_mode,
             document,
             thumbnail,
+            disable_notification,
         }
     }
 }

--- a/src/http/request/models/sendlocation.rs
+++ b/src/http/request/models/sendlocation.rs
@@ -25,6 +25,7 @@ pub struct SendLocationRequestModel {
     chat_id: ChatId,
     latitude: f32,
     longitude: f32,
+    disable_notification: bool,
 }
 
 impl TryFrom<SendLocationRequestModel> for Form {
@@ -34,10 +35,17 @@ impl TryFrom<SendLocationRequestModel> for Form {
         debug!("Converting SendLocationRequestModel to Form...");
         let chat_id = m.chat_id.to_string();
 
-        Ok(Form::new()
+        let initial_form = Form::new()
             .text("chat_id", chat_id)
             .text("latitude", m.latitude.to_string())
-            .text("longitude", m.longitude.to_string()))
+            .text("longitude", m.longitude.to_string());
+
+        let notification_form = match m.disable_notification {
+            true => initial_form.text("disable_notification", "true"),
+            false => initial_form,
+        };
+
+        Ok(notification_form)
     }
 }
 
@@ -52,11 +60,13 @@ impl From<SendLocationParams> for SendLocationRequestModel {
 
         let latitude = params.3.latitude;
         let longitude = params.3.longitude;
+        let disable_notification = params.2.silent;
 
         SendLocationRequestModel {
             chat_id,
             latitude,
             longitude,
+            disable_notification,
         }
     }
 }

--- a/src/http/request/models/sendmessage.rs
+++ b/src/http/request/models/sendmessage.rs
@@ -29,6 +29,7 @@ pub struct SendMessageRequestModel {
     chat_id: ChatId,
     text: String,
     parse_mode: ParseMode,
+    disable_notification: bool,
 }
 
 impl TryFrom<SendMessageRequestModel> for Form {
@@ -39,10 +40,17 @@ impl TryFrom<SendMessageRequestModel> for Form {
         let chat_id = m.chat_id.to_string();
         let parse_mode = m.parse_mode.to_string();
 
-        Ok(Form::new()
+        let initial_form = Form::new()
             .text("chat_id", chat_id)
             .text("text", m.text)
-            .text("parse_mode", parse_mode))
+            .text("parse_mode", parse_mode);
+
+        let notification_form = match m.disable_notification {
+            true => initial_form.text("disable_notification", "true"),
+            false => initial_form,
+        };
+
+        Ok(notification_form)
     }
 }
 
@@ -62,10 +70,13 @@ impl From<SendMessageParams> for SendMessageRequestModel {
             send::MessageFormat::HTML => ParseMode::HTML,
         };
 
+        let disable_notification = params.2.silent;
+
         SendMessageRequestModel {
             chat_id,
             text,
             parse_mode,
+            disable_notification,
         }
     }
 }

--- a/src/http/request/models/sendphoto.rs
+++ b/src/http/request/models/sendphoto.rs
@@ -29,6 +29,7 @@ pub struct SendPhotoRequestModel {
     photo: InputFile,
     caption: Option<String>,
     parse_mode: ParseMode,
+    disable_notification: bool,
 }
 
 impl TryFrom<SendPhotoRequestModel> for Form {
@@ -62,7 +63,12 @@ impl TryFrom<SendPhotoRequestModel> for Form {
             InputFile::Id(i) => caption_form.text("photo", i),
         };
 
-        Ok(photo_form)
+        let notification_form = match m.disable_notification {
+            true => photo_form.text("disable_notification", "true"),
+            false => photo_form,
+        };
+
+        Ok(notification_form)
     }
 }
 
@@ -84,11 +90,14 @@ impl From<SendPhotoParams> for SendPhotoRequestModel {
 
         let photo = InputFile::Local(params.3.file);
 
+        let disable_notification = params.2.silent;
+
         SendPhotoRequestModel {
             chat_id,
             caption,
             parse_mode,
             photo,
+            disable_notification,
         }
     }
 }

--- a/src/http/request/models/sendpoll.rs
+++ b/src/http/request/models/sendpoll.rs
@@ -26,6 +26,7 @@ pub struct SendPollRequestModel {
     chat_id: ChatId,
     question: String,
     options: Vec<String>,
+    disable_notification: bool,
 }
 
 impl TryFrom<SendPollRequestModel> for Form {
@@ -36,10 +37,17 @@ impl TryFrom<SendPollRequestModel> for Form {
         let chat_id = m.chat_id.to_string();
         let options = json!(m.options).to_string();
 
-        Ok(Form::new()
+        let initial_form = Form::new()
             .text("chat_id", chat_id)
             .text("question", m.question)
-            .text("options", options))
+            .text("options", options);
+
+        let notification_form = match m.disable_notification {
+            true => initial_form.text("disable_notification", "true"),
+            false => initial_form,
+        };
+
+        Ok(notification_form)
     }
 }
 
@@ -54,11 +62,13 @@ impl From<SendPollParams> for SendPollRequestModel {
 
         let question = params.3.question;
         let options = params.3.options;
+        let disable_notification = params.2.silent;
 
         SendPollRequestModel {
             chat_id,
             question,
             options,
+            disable_notification,
         }
     }
 }

--- a/src/http/request/models/sendvideo.rs
+++ b/src/http/request/models/sendvideo.rs
@@ -31,6 +31,7 @@ pub struct SendVideoRequestModel {
     height: Option<usize>,
     caption: Option<String>,
     parse_mode: ParseMode,
+    disable_notification: bool,
 }
 
 impl TryFrom<SendVideoRequestModel> for Form {
@@ -74,7 +75,12 @@ impl TryFrom<SendVideoRequestModel> for Form {
             None => width_form,
         };
 
-        Ok(height_form)
+        let notification_form = match m.disable_notification {
+            true => height_form.text("disable_notification", "true"),
+            false => height_form,
+        };
+
+        Ok(notification_form)
     }
 }
 
@@ -98,6 +104,8 @@ impl From<SendVideoParams> for SendVideoRequestModel {
         let width = params.3.horizontal;
         let height = params.3.vertical;
 
+        let disable_notification = params.2.silent;
+
         SendVideoRequestModel {
             chat_id,
             caption,
@@ -105,6 +113,7 @@ impl From<SendVideoParams> for SendVideoRequestModel {
             video,
             width,
             height,
+            disable_notification,
         }
     }
 }

--- a/src/operations/bot/send/mod.rs
+++ b/src/operations/bot/send/mod.rs
@@ -32,13 +32,15 @@ pub enum MessageFormat {
 pub struct SendParams {
     pub receiver: String,
     pub format: MessageFormat,
+    pub no_notify: bool,
 }
 
 impl SendParams {
-    pub fn new(receiver: &str, format: MessageFormat) -> Self {
+    pub fn new(receiver: &str, format: MessageFormat, no_notify: bool) -> Self {
         Self {
             receiver: String::from(receiver),
             format,
+            no_notify,
         }
     }
 }

--- a/src/operations/bot/send/mod.rs
+++ b/src/operations/bot/send/mod.rs
@@ -32,15 +32,15 @@ pub enum MessageFormat {
 pub struct SendParams {
     pub receiver: String,
     pub format: MessageFormat,
-    pub no_notify: bool,
+    pub silent: bool,
 }
 
 impl SendParams {
-    pub fn new(receiver: &str, format: MessageFormat, no_notify: bool) -> Self {
+    pub fn new(receiver: &str, format: MessageFormat, silent: bool) -> Self {
         Self {
             receiver: String::from(receiver),
             format,
-            no_notify,
+            silent,
         }
     }
 }

--- a/tests/bot_send_audio.rs
+++ b/tests/bot_send_audio.rs
@@ -60,21 +60,3 @@ fn send_audio_with_metadata(mut binary: Command) {
 
     assertion.success();
 }
-
-#[rstest]
-fn send_audio_silent_notification(mut binary: Command) {
-    let assertion = binary
-        .args([
-            "bot",
-            "send",
-            "audio",
-            "resources/test/audio.wav",
-            "--silent",
-            "--receiver",
-            &env::var("TELEGRAM_RECEIVER")
-                .expect("TELEGRAM_RECEIVER environment variable could not be found. Please create .env file and define it.")
-        ])
-        .assert();
-
-    assertion.success();
-}

--- a/tests/bot_send_audio.rs
+++ b/tests/bot_send_audio.rs
@@ -60,3 +60,21 @@ fn send_audio_with_metadata(mut binary: Command) {
 
     assertion.success();
 }
+
+#[rstest]
+fn send_audio_silent_notification(mut binary: Command) {
+    let assertion = binary
+        .args([
+            "bot",
+            "send",
+            "audio",
+            "resources/test/audio.wav",
+            "--silent",
+            "--receiver",
+            &env::var("TELEGRAM_RECEIVER")
+                .expect("TELEGRAM_RECEIVER environment variable could not be found. Please create .env file and define it.")
+        ])
+        .assert();
+
+    assertion.success();
+}

--- a/tests/bot_send_message.rs
+++ b/tests/bot_send_message.rs
@@ -84,3 +84,21 @@ fn send_message_format(mut binary: Command, #[values("markdown", "html")] format
 
     assertion.success();
 }
+
+#[rstest]
+fn send_message_silent(mut binary: Command) {
+    let assertion = binary
+        .args([
+            "bot",
+            "send",
+            "message",
+            "foo",
+            "--silent",
+            "--receiver",
+            &env::var("TELEGRAM_RECEIVER")
+                .expect("TELEGRAM_RECEIVER environment variable could not be found. Please create .env file and define it."),
+        ])
+        .assert();
+
+    assertion.success();
+}


### PR DESCRIPTION
New `send --silent` global argument helps you supress the notification sound on the target device.